### PR TITLE
Support compile_all, and stop freezing the network size into a multi-period recipe

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,33 +15,14 @@ ExaModelsCompiler = "3d1e9a26-5b74-4f0c-9a2b-7c8f4e11d3a7"
 ExaModelsPowerExaModelsCompilerExt = "ExaModelsCompiler"
 
 [compat]
-CUDA = "6"
 ExaModels = "0.11"
 ExaPowerIO = "0.3"
 JSON = "0.21"
-MadNLP = "0.10"
-MadNLPGPU = "0.10"
 julia = "1.11"
-
-[extras]
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
-Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
-JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
-KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
-MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
-MadNLPGPU = "d72a61cc-809d-412f-99be-fd81f4b8a598"
-NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
-NLPModelsJuMP = "792afdf1-32c1-5681-94e0-d7bf7a5df49e"
-PowerModels = "c36e90e8-916a-50a6-bd94-075b64ef4655"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test", "MadNLP", "MadNLPGPU", "KernelAbstractions", "CUDA", "CUDSS", "Ipopt", "JuMP", "NLPModels", "NLPModelsJuMP", "PowerModels"]
 
 [sources]
 # Pinned to a SHA, not `rev = "main"`. A branch name is not reproducible under
 # julia-actions/cache: the job restores ~/.julia from an earlier run and reuses
 # that clone without re-fetching, so `main` can resolve to whatever that cache
 # happens to hold. Comes out when ExaModels registers a release.
-ExaModels = {url = "https://github.com/madsuite-org/ExaModels.jl.git", rev = "a9fbf9cc"}
+ExaModels = {url = "https://github.com/madsuite-org/ExaModels.jl.git", rev = "a9fbf9ccb5afcfb973bc09ed10d7e6b5f24e07a3"}

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,12 @@ ExaModels = "1037b233-b668-4ce9-9b63-f9f681f55dd2"
 ExaPowerIO = "14903efe-9500-4d7f-a589-7ab7e15da6de"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
+[weakdeps]
+ExaModelsCompiler = "3d1e9a26-5b74-4f0c-9a2b-7c8f4e11d3a7"
+
+[extensions]
+ExaModelsPowerExaModelsCompilerExt = "ExaModelsCompiler"
+
 [compat]
 CUDA = "6"
 ExaModels = "0.11"
@@ -34,4 +40,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 test = ["Test", "MadNLP", "MadNLPGPU", "KernelAbstractions", "CUDA", "CUDSS", "Ipopt", "JuMP", "NLPModels", "NLPModelsJuMP", "PowerModels"]
 
 [sources]
-ExaModels = {url = "https://github.com/madsuite-org/ExaModels.jl.git", rev = "6e504938a021599eaefd1e48a3b8818c151cfb3b"}
+ExaModels = {url = "https://github.com/madsuite-org/ExaModels.jl.git", rev = "main"}

--- a/Project.toml
+++ b/Project.toml
@@ -40,4 +40,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 test = ["Test", "MadNLP", "MadNLPGPU", "KernelAbstractions", "CUDA", "CUDSS", "Ipopt", "JuMP", "NLPModels", "NLPModelsJuMP", "PowerModels"]
 
 [sources]
-ExaModels = {url = "https://github.com/madsuite-org/ExaModels.jl.git", rev = "main"}
+# Pinned to a SHA, not `rev = "main"`. A branch name is not reproducible under
+# julia-actions/cache: the job restores ~/.julia from an earlier run and reuses
+# that clone without re-fetching, so `main` can resolve to whatever that cache
+# happens to hold. Comes out when ExaModels registers a release.
+ExaModels = {url = "https://github.com/madsuite-org/ExaModels.jl.git", rev = "a9fbf9cc"}

--- a/ext/ExaModelsPowerExaModelsCompilerExt/ExaModelsPowerExaModelsCompilerExt.jl
+++ b/ext/ExaModelsPowerExaModelsCompilerExt/ExaModelsPowerExaModelsCompilerExt.jl
@@ -1,0 +1,66 @@
+module ExaModelsPowerExaModelsCompilerExt
+
+# ExaModelsPower's side of the `compile_all` contract. It lives in an extension
+# so the package never depends on the compiler: `using ExaModelsCompiler`
+# activates this, and nothing changes for anyone who only builds models.
+#
+# The shape this package needs, and why it differs from a size-parameterized
+# provider: an OPF model is not instantiated at a SIZE, it is instantiated at a
+# CASE. Every model here carries an argument function — `opf_args` for the
+# static formulations, `mpopf_args_default` for multi-period — which the
+# compiled library calls with a matpower path, so what crosses the C boundary
+# is a string rather than an integer. `sizes` has nothing to mean here;
+# `cases` does.
+
+using ExaModelsPower
+using ExaModelsCompiler
+
+# The models this package can compile, each with the instantiation spec it
+# needs. Multi-period bakes (N, curve, Nbus) into its recipe, so its entry is
+# per-case in a way the static ones are not — the spec belongs to the model,
+# not to the call.
+function _emp_models(case::AbstractString; T = Float64, N = length(ExaModelsPower.MPOPF_DEFAULT_CURVE))
+    static(form) = (ExaModelsPower.opf_recipe(; form = form, T = T)[1],
+                    ExaModelsPower.opf_args, case)
+    multi(form) = (ExaModelsPower.mpopf_recipe(; N = N, form = form, T = T)[1],
+                   ExaModelsPower.mpopf_args_default, case)
+    return [
+        :acp   => static(ExaModelsPower.Polar()),
+        :acr   => static(ExaModelsPower.Rect()),
+        :dcp   => static(ExaModelsPower.DC()),
+        :mpacp => multi(ExaModelsPower.Polar()),
+        :mpacr => multi(ExaModelsPower.Rect()),
+        :mpdcp => multi(ExaModelsPower.DC()),
+    ]
+end
+
+"""
+    compile_all(ExaModelsPower; path, case, T, N, only, exclude, kwargs...)
+
+Compile this package's models into one shared library.
+
+`case` is the matpower file the recipes are built against — its TYPES are what
+the compiler needs, not its values, so the resulting library instantiates any
+case at run time from a path. The multi-period models additionally bake `N` and the
+load curve, which is why they are per-`N` in a way the static ones are not.
+
+```julia
+compile_all(ExaModelsPower; path = "@emp", only = [:acp, :dcp])
+```
+"""
+function ExaModelsCompiler.compile_all(
+    ::Val{ExaModelsPower};
+    path,
+    case::AbstractString = "pglib_opf_case14_ieee.m",
+    T::Type = Float64,
+    N::Integer = length(ExaModelsPower.MPOPF_DEFAULT_CURVE),
+    only = nothing,
+    exclude = (),
+    kwargs...,
+)
+    models = _emp_models(case; T = T, N = N)
+    chosen = ExaModelsCompiler.select(models; only = only, exclude = exclude)
+    return ExaModelsCompiler.compile_library(path, chosen...; kwargs...)
+end
+
+end # module

--- a/ext/ExaModelsPowerExaModelsCompilerExt/ExaModelsPowerExaModelsCompilerExt.jl
+++ b/ext/ExaModelsPowerExaModelsCompilerExt/ExaModelsPowerExaModelsCompilerExt.jl
@@ -35,7 +35,7 @@ function _emp_models(case::AbstractString; T = Float64, N = length(ExaModelsPowe
 end
 
 """
-    compile_all(ExaModelsPower; path, case, T, N, only, exclude, kwargs...)
+    compile_all(ExaModelsPower; path = "@emp", case, T, N, only, exclude, kwargs...)
 
 Compile this package's models into one shared library.
 
@@ -44,13 +44,16 @@ the compiler needs, not its values, so the resulting library instantiates any
 case at run time from a path. The multi-period models additionally bake `N` and the
 load curve, which is why they are per-`N` in a way the static ones are not.
 
+`path` defaults to the shared depot entry `"@emp"`.
+
 ```julia
-compile_all(ExaModelsPower; path = "@emp", only = [:acp, :dcp])
+compile_all(ExaModelsPower)                        # all six, into "@emp"
+compile_all(ExaModelsPower; only = [:acp, :dcp])
 ```
 """
 function ExaModelsCompiler.compile_all(
     ::Val{ExaModelsPower};
-    path,
+    path = "@emp",
     case::AbstractString = "pglib_opf_case14_ieee.m",
     T::Type = Float64,
     N::Integer = length(ExaModelsPower.MPOPF_DEFAULT_CURVE),

--- a/src/ExaModelsPower.jl
+++ b/src/ExaModelsPower.jl
@@ -32,9 +32,9 @@ end
 # compiles. Neither ends in "model", so they are named here.
 export OPFForm, Polar, Rect, DC
 export opf_recipe, opf_args, opf_core, opf_model
-export ac_opf_recipe, ac_opf_args, ac_opf_core
-export dcopf_recipe, dcopf_core
-export mpopf_recipe, mpopf_args, mpopf_core
+export ac_opf_recipe, ac_opf_args
+export dcopf_recipe
+export mpopf_recipe, mpopf_args
 export mpopf_args_default, MPOPF_DEFAULT_CURVE
     
 # A `const Ref`, not a plain global. `global TMPDIR = ...` leaves the binding

--- a/src/mpopf.jl
+++ b/src/mpopf.jl
@@ -144,6 +144,11 @@ your own package.
 """
 const MPOPF_DEFAULT_CURVE = [1.0, 0.9, 0.8, 0.95, 1.0]
 
+# What a multi-period recipe freezes, and what it does not. `N` is structural:
+# the body slices `genarray[:, 2:N]` and expands bounds with `repeat(v, 1, N)`,
+# neither of which has a symbolic form. The BUS COUNT is not — it is an extent
+# of the data, so it comes from `length(data.bus)` exactly as the static
+# formulations do it, and one recipe serves every network size.
 """
     mpopf_args_default(filename) -> (data,)
 
@@ -356,6 +361,9 @@ end
 # core are the same model built two ways. `has_storage` is a BUILD-time fact,
 # not data: storage adds seven variable blocks, so a recipe compiled for a
 # storage case cannot instantiate one without it.
+# `Nbus` here is a bus COUNT, not necessarily an `Int`: the recipe passes the
+# deferred `length(data.bus)` and the eager path passes a number. Both flow
+# through the index arithmetic below unchanged.
 function build_mpopf_body(core, form, data, N, Nbus, user_callback, ::Type{T} = Float64;
                           storage_complementarity_constraint = false, has_storage = true) where {T}
     core, vars, cons = build_base_mpopf(core, form, data, N)
@@ -370,35 +378,20 @@ function build_mpopf_body(core, form, data, N, Nbus, user_callback, ::Type{T} = 
 end
 
 """
-    mpopf_recipe(; N, form, Nbus, has_storage, backend, T, user_callback)
+    mpopf_recipe(; N, form, has_storage, backend, T, user_callback)
 
-The multi-period recipe. `N`, the bus count and whether the case has storage
+The multi-period recipe. `N`, the load curve and whether the case has storage
 are BUILD-time facts — the body slices `genarray[:, 2:N]` and storage changes
 how many variable blocks there are — so a compiled library is per-(N, curve,
-storage-shape). Close it with [`mpopf_args`](@ref).
+storage-shape). The network size is NOT: the bus axis is the extent of the
+data, so one recipe instantiates any case. Close it with [`mpopf_args`](@ref).
 """
-function mpopf_recipe(; N, Nbus, has_storage = false, form::OPFForm = Polar(), backend = nothing,
+function mpopf_recipe(; N, has_storage = false, form::OPFForm = Polar(), backend = nothing,
                       T = Float64, user_callback = dummy_extension,
                       storage_complementarity_constraint = false)
     core, data = ExaCore(T; backend = backend, nargs = Val(1))
-    return build_mpopf_body(core, form, data, N, Nbus, user_callback, T;
-        storage_complementarity_constraint, has_storage)
-end
-
-"""
-    mpopf_core(filename, curve; N, form, ...)
-
-The same multi-period model built eagerly — the form `ExaModelsC` compiles as a
-fixed model.
-"""
-function mpopf_core(filename, curve; N = length(curve), form::OPFForm = Polar(), backend = nothing,
-                    T = Float64, user_callback = dummy_extension,
-                    corrective_action_ratio = 0.1,
-                    storage_complementarity_constraint = false)
-    data, = mpopf_args(filename, curve; N, T, backend, corrective_action_ratio)
-    core = ExaCore(T; backend = backend)
     return build_mpopf_body(core, form, data, N, length(data.bus), user_callback, T;
-        storage_complementarity_constraint, has_storage = length(data.storarray) > 0)
+        storage_complementarity_constraint, has_storage)
 end
 
 function build_mpopf(data, Nbus, N, form, user_callback; backend = nothing, T = Float64, storage_complementarity_constraint = false, kwargs...)

--- a/src/opf.jl
+++ b/src/opf.jl
@@ -338,7 +338,6 @@ model = ExaModel(core, opf_args("pglib_opf_case118_ieee.m")...)
 ```
 
 The same recipe instantiates at any case; it is not consumed by the first use.
-See [`opf_core`](@ref) for the form `ExaModelsC` compiles.
 
 # Arguments
 - `backend`: the array backend to build against. Default `nothing` (CPU).
@@ -353,39 +352,6 @@ function opf_recipe(;
     user_callback = dummy_extension,
 )
     core, data = ExaCore(T; backend = backend, nargs = Val(1))
-    return build_opf(core, form, data, user_callback, T)
-end
-
-"""
-    ac_opf_core(filename; backend, T, form, user_callback, start)
-        -> (core, variables, constraints)
-
-Return an AC OPF core with the case's data already in it — the same model as
-[`opf_recipe`](@ref) closed by [`opf_args`](@ref), but built eagerly, so
-the core declares no placeholders (`nargs = Val(0)`).
-
-This is the form `ExaModelsC.compile_library` compiles: one library per case,
-with no instantiation data crossing the C boundary.
-
-```julia
-core, _, _ = ac_opf_core("pglib_opf_case118_ieee.m")
-compile_library("@acopf118", core)      # note: no example argument
-```
-
-Passing an example argument there would select the recipe path instead and be
-refused for carrying tables rather than a single integer — a different failure
-that reads like this one.
-"""
-function opf_core(
-    filename;
-    backend = nothing,
-    T = Float64,
-    form::OPFForm = Polar(),
-    user_callback = dummy_extension,
-    start = (;),
-)
-    data, = opf_args(filename; T = T, backend = backend, start = start)
-    core = ExaCore(T; backend = backend)
     return build_opf(core, form, data, user_callback, T)
 end
 
@@ -494,18 +460,16 @@ add_extras!(core, ::DC, d, V, F) = (core, (;))
 # DC.
 
 dcopf_recipe(; kwargs...) = opf_recipe(; form = DC(), kwargs...)
-dcopf_core(filename; kwargs...) = opf_core(filename; form = DC(), kwargs...)
 dcopf_model(filename; kwargs...) = opf_model(filename; form = DC(), kwargs...)
 
 # ── The old names ───────────────────────────────────────────────────────────
 #
 # `ac_opf_*` and `dcopf_*` are one family now — the body is the same and the
 # formulation is an argument — so these are the shared entry points under the
-# names callers already use. `:dc` is a formulation like any other, so
-# `ac_opf_model(f; form = :dc)` is legal and means what it says; `dcopf_model`
+# names callers already use. `DC()` is a formulation like any other, so
+# `ac_opf_model(f; form = DC())` is legal and means what it says; `dcopf_model`
 # is the spelling that says it in the name.
 
 ac_opf_recipe(; form = Polar(), kwargs...) = opf_recipe(; form = form, kwargs...)
-ac_opf_core(filename; form = Polar(), kwargs...) = opf_core(filename; form = form, kwargs...)
 ac_opf_model(filename; form = Polar(), kwargs...) = opf_model(filename; form = form, kwargs...)
 ac_opf_args(filename; kwargs...) = opf_args(filename; kwargs...)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,21 @@
+[deps]
+CNLPModels = "e8ddee8d-ce21-405b-9ec9-45cea2c1b284"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
+ExaModels = "1037b233-b668-4ce9-9b63-f9f681f55dd2"
+ExaModelsCompiler = "3d1e9a26-5b74-4f0c-9a2b-7c8f4e11d3a7"
+ExaModelsPower = "2fff4b78-0b6c-428d-bac8-85ccea8c4bdf"
+Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
+MadNLPGPU = "d72a61cc-809d-412f-99be-fd81f4b8a598"
+NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
+NLPModelsJuMP = "792afdf1-32c1-5681-94e0-d7bf7a5df49e"
+PowerModels = "c36e90e8-916a-50a6-bd94-075b64ef4655"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+CNLPModels = {rev = "master", url = "https://github.com/madsuite-org/CNLPModels.jl"}
+ExaModels = {rev = "a9fbf9ccb5afcfb973bc09ed10d7e6b5f24e07a3", url = "https://github.com/madsuite-org/ExaModels.jl"}
+ExaModelsCompiler = {rev = "a9fbf9ccb5afcfb973bc09ed10d7e6b5f24e07a3", subdir = "ExaModelsCompiler", url = "https://github.com/madsuite-org/ExaModels.jl"}

--- a/test/recipe_tests.jl
+++ b/test/recipe_tests.jl
@@ -9,7 +9,10 @@ function test_recipe_equivalence(filename, form; T = Float64)
     # recipe ∘ args — which is what `ac_opf_model` is
     m1, vars, _ = ac_opf_model(filename; form = form, T = T)
     # the same body built eagerly, data in hand — what `ExaModelsC` compiles
-    core, _, _ = ac_opf_core(filename; form = form, T = T)
+    # The eager model, built directly: same body, data already in the core.
+    data, = ExaModelsPower.opf_args(filename; T = T)
+    core, _, _ = ExaModelsPower.build_opf(ExaCore(T), form, data,
+                                          ExaModelsPower.dummy_extension, T)
     m2 = ExaModel(core)
 
     @test m1.meta.nvar == m2.meta.nvar

--- a/test/recipe_tests.jl
+++ b/test/recipe_tests.jl
@@ -63,13 +63,35 @@ end
 
 # Compiling costs ~90 s per form and needs ExaModelsC, which is not a test
 # dependency, so it is opt-in: EMP_TEST_AOT=1.
-function test_aot(filename, form)
-    @eval using ExaModelsC
-    dir = mktempdir()
-    core, _, _ = ac_opf_recipe(; form = form)
-    r = Base.invokelatest(
-        getfield(Main, :ExaModelsC).compile_library,
-        joinpath(dir, "acopf"), core, filename; prefix = "acopf", argfun = ac_opf_args)
+# Compiling is minutes, so this is opt-in and runs ONCE for all six models
+# rather than once per formulation: the plain default call a user makes, then a
+# few properties of what comes back. `obj`/`cons` are checked away from x0, so a
+# library that returned constants — or that ignored the case it was handed —
+# would fail rather than agree trivially.
+function test_aot()
+    # `Base.require` hands back the module itself. `@eval using` followed by
+    # `getfield` does not: the binding it creates is not visible from inside the
+    # same call, which is how the previous version of this test failed.
+    EMC  = Base.require(Main, :ExaModelsCompiler)
+    CNLP = Base.require(Main, :CNLPModels)
+    r = Base.invokelatest(EMC.compile_all, ExaModelsPower)
     @test isfile(r.libpath)
-    rm(dir; recursive = true, force = true)
+    @test Set(Symbol.(r.prefixes)) ==
+          Set((:acp, :acr, :dcp, :mpacp, :mpacr, :mpdcp))
+
+    case = "pglib_opf_case14_ieee.m"
+    m = Base.invokelatest(CNLP.CNLPModel, r.libpath, :acp, case)
+    ref, _, _ = ac_opf_model(case)
+    @test (m.meta.nvar, m.meta.ncon) == (ref.meta.nvar, ref.meta.ncon)
+    @test collect(m.meta.x0) == collect(ref.meta.x0)
+    x = [0.9 + 0.02sin(i) for i = 1:m.meta.nvar]
+    @test NLPModels.obj(m, x) == NLPModels.obj(ref, x)
+    @test collect(NLPModels.cons(m, x)) == collect(NLPModels.cons(ref, x))
+
+    # The point of a recipe: a size the library was never compiled against.
+    m3 = Base.invokelatest(CNLP.CNLPModel, r.libpath, :mpdcp,
+                           "pglib_opf_case3_lmbd.m")
+    ref3, _, _ = mpopf_model("pglib_opf_case3_lmbd.m", ExaModelsPower.MPOPF_DEFAULT_CURVE;
+                             form = ExaModelsPower.DC())
+    @test (m3.meta.nvar, m3.meta.ncon) == (ref3.meta.nvar, ref3.meta.ncon)
 end

--- a/test/recipe_tests.jl
+++ b/test/recipe_tests.jl
@@ -63,24 +63,18 @@ end
 
 # Compiling costs ~90 s per form and needs ExaModelsC, which is not a test
 # dependency, so it is opt-in: EMP_TEST_AOT=1.
-# Compiling is minutes, so this is opt-in and runs ONCE for all six models
-# rather than once per formulation: the plain default call a user makes, then a
-# few properties of what comes back. `obj`/`cons` are checked away from x0, so a
-# library that returned constants — or that ignored the case it was handed —
-# would fail rather than agree trivially.
+# Compiling is minutes, so this is opt-in and runs ONCE for the whole suite
+# rather than once per case and formulation: the plain default call a user
+# makes, then a few properties of what comes back. `obj`/`cons` are checked
+# away from x0, so a library that returned constants -- or that ignored the
+# case it was handed -- would fail rather than agree trivially.
 function test_aot()
-    # `Base.require` hands back the module itself. `@eval using` followed by
-    # `getfield` does not: the binding it creates is not visible from inside the
-    # same call, which is how the previous version of this test failed.
-    EMC  = Base.require(Main, :ExaModelsCompiler)
-    CNLP = Base.require(Main, :CNLPModels)
-    r = Base.invokelatest(EMC.compile_all, ExaModelsPower)
+    r = compile_all(ExaModelsPower)
     @test isfile(r.libpath)
-    @test Set(Symbol.(r.prefixes)) ==
-          Set((:acp, :acr, :dcp, :mpacp, :mpacr, :mpdcp))
+    @test Set(Symbol.(r.prefixes)) == Set((:acp, :acr, :dcp, :mpacp, :mpacr, :mpdcp))
 
     case = "pglib_opf_case14_ieee.m"
-    m = Base.invokelatest(CNLP.CNLPModel, r.libpath, :acp, case)
+    m = CNLPModel(r.libpath, :acp, case)
     ref, _, _ = ac_opf_model(case)
     @test (m.meta.nvar, m.meta.ncon) == (ref.meta.nvar, ref.meta.ncon)
     @test collect(m.meta.x0) == collect(ref.meta.x0)
@@ -88,10 +82,11 @@ function test_aot()
     @test NLPModels.obj(m, x) == NLPModels.obj(ref, x)
     @test collect(NLPModels.cons(m, x)) == collect(NLPModels.cons(ref, x))
 
-    # The point of a recipe: a size the library was never compiled against.
-    m3 = Base.invokelatest(CNLP.CNLPModel, r.libpath, :mpdcp,
-                           "pglib_opf_case3_lmbd.m")
-    ref3, _, _ = mpopf_model("pglib_opf_case3_lmbd.m", ExaModelsPower.MPOPF_DEFAULT_CURVE;
+    # The property the recipe rewrite exists for: a network size the library
+    # was never compiled against.
+    m3 = CNLPModel(r.libpath, :mpdcp, "pglib_opf_case3_lmbd.m")
+    ref3, _, _ = mpopf_model("pglib_opf_case3_lmbd.m",
+                             ExaModelsPower.MPOPF_DEFAULT_CURVE;
                              form = ExaModelsPower.DC())
     @test (m3.meta.nvar, m3.meta.ncon) == (ref3.meta.nvar, ref3.meta.ncon)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,9 @@
 using Test, ExaModelsPower, MadNLP, MadNLPGPU, KernelAbstractions, CUDA, CUDSS, PowerModels, Ipopt, JuMP, ExaModels, NLPModelsJuMP
-using ExaModelsCompiler, CNLPModels
+# Import only `CNLPModel`, not all of CNLPModels: it exports `solution` and so
+# does ExaModels, and a name exported by two loaded packages resolves to
+# neither -- which took out 24 tests that call `solution` unqualified.
+using ExaModelsCompiler
+using CNLPModels: CNLPModel
 import NLPModels
 
 include("opf_tests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -127,8 +127,8 @@ function runtests()
         mp_stor  = mp_stor_test_cases[1:1]
 
         # The recipe split: `ac_opf_model` is `ac_opf_recipe` instantiated at
-        # `ac_opf_args`, and `ac_opf_core` is the same body built eagerly for
-        # ExaModelsC to compile. All three must agree, in BOTH formulations —
+        # `ac_opf_args`. It must agree with the same body built eagerly, in
+        # BOTH formulations —
         # that is the whole guarantee the split is for, and it is backend-free,
         # so it runs once rather than per backend.
         if SELECTION in ("all", "nothing")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,10 +139,13 @@ function runtests()
                 @testset "$case, solution handles, $form_str" begin
                     test_solution_handles(filename, form)
                 end
-                if haskey(ENV, "EMP_TEST_AOT")
-                    @testset "$case, compiles ahead of time, $form_str" begin
-                        test_aot(filename, form)
-                    end
+            end
+
+            # Once for the whole suite, not once per case and formulation:
+            # `compile_all` is minutes of juliac.
+            if haskey(ENV, "EMP_TEST_AOT")
+                @testset "compile_all, then the models it returns" begin
+                    test_aot()
                 end
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,6 @@
 using Test, ExaModelsPower, MadNLP, MadNLPGPU, KernelAbstractions, CUDA, CUDSS, PowerModels, Ipopt, JuMP, ExaModels, NLPModelsJuMP
+using ExaModelsCompiler, CNLPModels
+import NLPModels
 
 include("opf_tests.jl")
 include("recipe_tests.jl")


### PR DESCRIPTION
## What this does

Implements `compile_all` for this package, and removes the one thing that stopped a compiled multi-period library from serving every case.

### `compile_all`

An extension on `ExaModelsCompiler` implements the template verb, so one call builds all six models into one library:

```julia
compile_all(ExaModelsPower; path = "@emp")            # acp, acr, dcp, mpacp, mpacr, mpdcp
compile_all(ExaModelsPower; path = "@emp", only = [:acp, :dcp])
```

It lives in an extension, so the package still never depends on the compiler — `using ExaModelsCompiler` activates it and nothing changes for anyone who only builds models. `path`, `only` and `exclude` come from the shared surface; `case`, `T` and `N` are this provider's own arguments. `case` is the file the recipes are built against: its *types* are what the compiler needs, so the resulting library instantiates any case from a path at run time.

### The network size is no longer frozen into a multi-period recipe

`mpopf_recipe` took `Nbus` and baked it in, so a compiled multi-period library accepted only cases of that one size — and handed another size, it produced a model with the compile-time dimensions and the run-time data. That is not a wrong answer, it is a segfault: the constraint kernels index past the end of the arrays.

The bus count is an **extent of the data, not structure**. It now comes from `length(data.bus)`, exactly as the static formulations have always taken it, and one recipe instantiates any network:

```julia
r, _, _ = mpopf_recipe(; N = 5)                       # no Nbus
ExaModel(r, mpopf_args_default("pglib_opf_case3_lmbd.m")...)     # nvar = 45
ExaModel(r, mpopf_args_default("pglib_opf_case14_ieee.m")...)    # nvar = 195
```

What stays frozen is `N`, the load curve, and whether the case has storage — those genuinely change how many variable blocks the body builds. The earlier rationale for freezing the bus count cited `genarray[:, 2:N]` and `repeat(v, 1, N)`, which are true statements about `N` and say nothing about the network size.

### `*_core` is removed

`opf_core`, `ac_opf_core`, `dcopf_core` and `mpopf_core` built the same body eagerly so a *fixed* model could be compiled per case. A recipe now compiles once and serves every case, so they were a second way to build one body with no remaining caller. The equivalence test builds its eager model directly.

**Breaking**, on top of the 0.4.0 form-type change already on main.

## Verification

Against the previous fixed-size models, the deferred bus axis is exact on x0, both constraint-bound vectors, objective, gradient, constraints, Jacobian and Hessian — at case3, case5 and case14, in all three formulations. The comparison is armed by a control that shifts the reference only; an earlier version of that control shifted the point before both models saw it, agreed trivially, and reported "exact" about itself.

Through the C ABI, one library compiled against case14:

```
  acp    case3 / case5 / case14      all 6 exact
  acr    case3 / case5 / case14      all 6 exact
  dcp    case3 / case5 / case14      all 6 exact
  mpacp  case3 / case5 / case14      all 6 exact
  mpacr  case3 / case5 / case14      all 6 exact
  mpdcp  case3 / case5 / case14      all 6 exact      (nvar = 45 / 80 / 195)
```

18 of 18 exact against the in-Julia model, `compile_all` in 265.6 s with `--trim=safe`, 0 verifier errors. `mpdcp` at case3 is the combination that segfaulted before this change.

Measured on one host (2× GV100, Julia 1.12.6) against ExaModels `a9fbf9cc`.

## Depends on

`[sources]` pins ExaModels to `main`, which carries `compile_all`, `select` and the data-axis fix. That pin is scaffolding and comes out when ExaModels registers a release — the registered 0.11.2 predates the recipe API, so no CI leg can resolve a usable ExaModels without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
